### PR TITLE
Fix/playbook change race condition

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -25,22 +25,22 @@ export class BladesAlternateActorSheet extends BladesSheet {
 
   /** @override **/
   async _onDropItem(event, droppedItem) {
+    await super._onDropItem(event, droppedItem);
     if (!this.actor.isOwner) {
       ui.notifications.error(`You do not have sufficient permissions to edit this character. Please speak to your GM if you feel you have reached this message in error.`, {permanent: true});
       return false;
     }
 	  await this.handleDrop(event, droppedItem);
-    return super._onDropItem(event, droppedItem);
   }
 
   /** @override **/
   async _onDropActor(event, droppedActor){
+    await super._onDropActor(event, droppedActor);
     if (!this.actor.isOwner) {
       ui.notifications.error(`You do not have sufficient permissions to edit this character. Please speak to your GM if you feel you have reached this message in error.`, {permanent: true});
       return false;
     }
     await this.handleDrop(event, droppedActor);
-    return super._onDropActor(event, droppedActor);
   }
 
   /** @override **/
@@ -102,7 +102,6 @@ export class BladesAlternateActorSheet extends BladesSheet {
         // await this.onDroppedDistinctItem(droppedEntityFull);
         break;
     }
-    return droppedEntity;
   }
 
   async addPlaybookAcquaintances(selected_playbook){


### PR DESCRIPTION
Possible fix for #6. Merging for testing. 

Essentially, when a new playbook/class gets dropped on the sheet, Foundry starts creating the item. BladesItem._preCreate() gets called, and gets ready to delete any existing class items, but 