### PR TITLE
Added code to convert the standard trauma array to an object for cons…

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -316,11 +316,14 @@ export class BladesAlternateActorSheet extends BladesSheet {
     // Prepare active effects
     data.effects = BladesActiveEffect.prepareActiveEffectCategories(this.actor.effects);
     let trauma_array = [];
-    for(const trauma in data.data.trauma.list){
-      if(data.data.trauma.list[trauma]){
-        trauma_array.push(trauma);
-      }
+    let trauma_object = {};
+
+    if(Array.isArray(data.data.trauma.list)){
+      trauma_object = Utils.convertArrayToBooleanObject(data.data.trauma.list);
+      trauma_object = expandObject({"data.trauma.list": trauma_object});
+      await this.actor.update(trauma_object);
     }
+    trauma_array = Utils.convertBooleanObjectToArray(data.data.trauma.list);
 
     data.trauma_array = trauma_array;
     data.trauma_count = trauma_array.length;
@@ -713,8 +716,14 @@ export class BladesAlternateActorSheet extends BladesSheet {
     });
 
     html.find('.add_trauma').click(async ev => {
-      let data = await this.getData();
-      let actorTraumaList = data.trauma_array;
+      // let data = await this.getData();
+      let actorTraumaList = [];
+      if(Array.isArray(this.actor.data.data.trauma.list)){
+        actorTraumaList = this.actor.data.data.trauma.list;
+      }
+      else{
+        actorTraumaList = Utils.convertBooleanObjectToArray(this.actor.data.data.trauma.list);
+      }
       let allTraumas = this.actor.data.data.trauma.options;
       let unownedTraumas = [];
       for (const traumaListKey of allTraumas) {
@@ -748,6 +757,7 @@ export class BladesAlternateActorSheet extends BladesSheet {
                   }
               };
               newTraumaListValue.data.trauma.list[newTrauma] = true;
+              console.log(newTrauma, newTraumaListValue);
               await this.actor.update(newTraumaListValue);
 
             }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -494,6 +494,33 @@ export class Utils {
     return doc.body.textContent || "";
   }
 
+  static convertArrayToBooleanObject(arr){
+    const obj = {};
+    for (const key of arr) {
+      obj[key] = true;
+    }
+    return obj;
+  }
+
+  static convertBooleanObjectToArray(obj){
+    return Object.keys(obj).filter(key => obj[key]);
+    // if(Array.isArray(obj))
+    //
+    //   let arr = [];
+    //   if(!Array.isArray(object)){
+    //     for(const el in object){
+    //       if(object[el]){
+    //         arr.push(el);
+    //       }
+    //     }
+    //     return arr;
+    //   }
+    //   else{
+    //     // console.log("Can't use convertBooleanObjectToArray on an array. Returning object untouched.");
+    //     return object;
+    //   }
+  }
+
   // This doesn't work as expected. It hasn't been updated
   static async modifiedFromPlaybookDefault(actor) {
     let skillsChanged = false;


### PR DESCRIPTION
Should fix #9. An issue was being caused by the fact that my sheets don't touch the trauma list until a trauma is added, and the system sheets convert them to an object (via the checkboxes/data binding). I've added code to just convert the traumas to an object in my sheets as well. 

It's not ideal and will have to be revisited to accommodate playbooks with different trauma lists, but it will do for now.