### PR TITLE
Signal that this module is v10-only

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,8 +5,12 @@
   "version": "0.0.1",
   "library": "false",
   "manifestPlusVersion": "1.2.0",
-  "minimumCoreVersion": "9",
-  "compatibleCoreVersion": "9",
+  "minimumCoreVersion": "10",
+  "compatibleCoreVersion": "10",
+  "compatibility": {
+    "minimum": 10,
+    "verified": 10
+  },
   "authors": [
     {
       "name": "Justin Ross",
@@ -25,7 +29,7 @@
     }
   ],
   "conflicts": [
-    
+
   ],
   "esmodules": [
     "/scripts/module.js"


### PR DESCRIPTION
I installed the module in a v9 Foundry, and the sheets refused to start up. The switchover from `thing.data` to `thing.system` in 5813d8fc20a958e68aa72dfb5baaa34849e1d5a0 means the module can no longer load in v9. This updates the Foundry manifest file to make it so that newer versions won't be considered for installation under v9.