### PR TITLE
Fixed adding homebrew playbook NPC contacts automatically

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -100,7 +100,10 @@ export class BladesAlternateActorSheet extends BladesSheet {
 
   async switchToPlaybookAcquaintances(selected_playbook){
     let all_acquaintances = await Utils.getSourcedItemsByType('npc');
-    let playbook_acquaintances = all_acquaintances.filter(item => item.system.associated_class === selected_playbook.name);
+    let playbook_acquaintances = all_acquaintances.filter(item => {
+      return item.system.associated_class.trim() === selected_playbook.name
+    });
+    console.log(playbook_acquaintances);
     let current_acquaintances = this.actor.system.acquaintances;
     let neutral_acquaintances = current_acquaintances.filter(acq => acq.standing === "neutral");
     await Utils.removeAcquaintanceArray(this.actor, neutral_acquaintances);

--- a/scripts/handlebars-helpers.js
+++ b/scripts/handlebars-helpers.js
@@ -11,6 +11,10 @@ export const registerHandlebarsHelpers = function() {
     return(arg1 || arg2);
   });
 
+  Handlebars.registerHelper('notempty', function(arg1){
+    return(arg1.trim().length > 0);
+  });
+
 
   Handlebars.registerHelper('inline-editable-text', function(editable, parameter_name, blank_value, current_value, uniq_id, context){
     let html = '';

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -168,16 +168,21 @@ export class Utils {
   static async getAllItemsByType(item_type) {
 
     let list_of_items = [];
-    let game_items = [];
+    let world_items = [];
     let compendium_items = [];
-
-    game_items = game.items.filter(e => e.type === item_type).map(e => {return e});
+    
+    if(item_type === "npc"){
+      world_items = game.actors.filter(e => e.type === item_type).map(e => {return e});
+    }
+    else{
+      world_items = game.items.filter(e => e.type === item_type).map(e => {return e});
+    }
 
     let pack = game.packs.find(e => e.metadata.name === item_type);
     let compendium_content = await pack.getDocuments();
     compendium_items = compendium_content.map(e => {return e});
 
-    list_of_items = game_items.concat(compendium_items);
+    list_of_items = world_items.concat(compendium_items);
     list_of_items.sort(function(a, b) {
       let nameA = a.name.toUpperCase();
       let nameB = b.name.toUpperCase();

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -127,7 +127,7 @@
                     {{#if (eq this.standing "friend" )}} fa-caret-up green-icon
                     {{else if (eq this.standing "rival")}} fa-caret-down red-icon
                     {{else}}fa-minus
-                    {{/if}}"></i><strong class="standing-toggle">{{this.name}}</strong>{{#if this.description_short}}, {{this.description_short}}{{/if}}
+                    {{/if}}"></i><strong class="standing-toggle">{{this.name}}</strong>{{#if (notempty this.description_short)}}, {{this.description_short}}{{/if}}
                 </div>
               {{/each}}
             {{/if}}


### PR DESCRIPTION
Should resolve issue #41.

Note that adding items and NPCs automatically still requires selection of the appropriate module setting: 

![image](https://user-images.githubusercontent.com/1120106/215588630-faad2db3-6dc3-4be1-853a-3f121f9998ba.png)
