### PR TITLE
Adding support for DC Load Levels

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -443,11 +443,20 @@ export class BladesAlternateActorSheet extends BladesSheet {
         ? Utils.getOwnedObjectByType(this.actor, "vice").name
         : "";
 
-    sheetData.load_levels = {
-      "BITD.Light": "BITD.Light",
-      "BITD.Normal": "BITD.Normal",
-      "BITD.Heavy": "BITD.Heavy",
-    };
+    if (game.settings.get('blades-in-the-dark', 'DeepCutLoad')) {
+      //Set up DC Load Levels
+      sheetData.load_levels = {
+        "BITD.Discreet": "BITD.Discreet",
+        "BITD.Conspicuous": "BITD.Conspicuous"
+      };
+    } else {
+      //Set up Traditional Load Levels
+      sheetData.load_levels = {
+        "BITD.Light": "BITD.Light",
+        "BITD.Normal": "BITD.Normal",
+        "BITD.Heavy": "BITD.Heavy",
+      };
+    }
 
     let owned_playbooks = this.actor.items.filter(
       (item) => item.type == "class"
@@ -567,21 +576,40 @@ export class BladesAlternateActorSheet extends BladesSheet {
 
     sheetData.loadout = loadout;
 
-    switch (sheetData.system.selected_load_level) {
-      case "BITD.Light":
-        sheetData.max_load = sheetData.system.base_max_load + 3;
-        break;
-      case "BITD.Normal":
-        sheetData.max_load = sheetData.system.base_max_load + 5;
-        break;
-      case "BITD.Heavy":
-        sheetData.max_load = sheetData.system.base_max_load + 6;
-        break;
-      default:
-        sheetData.system.selected_load_level = "BITD.Normal";
-        sheetData.max_load = sheetData.system.base_max_load + 5;
-        break;
+    if (game.settings.get('blades-in-the-dark', 'DeepCutLoad')) {
+      //Deep Cuts Load
+      switch (sheetData.system.selected_load_level) {
+        case "BITD.Discreet":
+          sheetData.max_load = sheetData.system.base_max_load + 4;
+          break;
+        case "BITD.Conspicuous":
+          sheetData.max_load = sheetData.system.base_max_load + 6;
+          break;
+        default:
+          sheetData.system.selected_load_level = "BITD.Discreet";
+          sheetData.max_load = sheetData.system.base_max_load + 4;
+          break;
+      }
     }
+    else {
+      //Traditional Load
+      switch (sheetData.system.selected_load_level) {
+        case "BITD.Light":
+          sheetData.max_load = sheetData.system.base_max_load + 3;
+          break;
+        case "BITD.Normal":
+          sheetData.max_load = sheetData.system.base_max_load + 5;
+          break;
+        case "BITD.Heavy":
+          sheetData.max_load = sheetData.system.base_max_load + 6;
+          break;
+        default:
+          sheetData.system.selected_load_level = "BITD.Normal";
+          sheetData.max_load = sheetData.system.base_max_load + 5;
+          break;
+      }
+    }
+
     return sheetData;
   }
 


### PR DESCRIPTION
There are a number of things to add to support Deep Cuts, but here's a small one.

Deep cuts has an optional module to change how Load levels work.

I added a toggle based on the System setting for if this modular rule is enabled, that changes the load selection to be 4/6 instead of 3/5/6. Should automatically use the localized strings and system setting value.

Cheers.