### PR TITLE
Refresh derived stats on alternate actor sheet

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -373,7 +373,14 @@ export class BladesAlternateActorSheet extends BladesSheet {
     sheetData.load_open = this.load_open;
     sheetData.allow_edit = this.allow_edit;
     sheetData.show_debug = this.show_debug;
-    sheetData.attributes = actorData.system.attributes;
+    const computedAttributes = this.actor.getComputedAttributes();
+    sheetData.system.attributes = computedAttributes;
+    sheetData.attributes = computedAttributes;
+    sheetData.system.stress.max = this.actor.getMaxStress();
+    sheetData.system.trauma.max = this.actor.getMaxTrauma();
+    if (sheetData.system?.healing_clock) {
+      sheetData.system.healing_clock.value = this.actor.getHealingMin();
+    }
     sheetData.acquaintances_label =
       sheetData.system.acquaintances_label == "BITD.Acquaintances"
         ? "bitd-alt.Acquaintances"


### PR DESCRIPTION
I ran into an issue that I saw mentioned on Discord where crew upgrades (like Steady) didn't propagate their effects on the alternate character sheets the way they do in the system default sheets. This patch fixed it for me.