### PR TITLE
fix: adopt namespaced ContextMenu API

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -803,18 +803,17 @@ export class BladesAlternateActorSheet extends BladesSheet {
     // Everything below here is only needed if the sheet is editable
     if (!this.options.editable) return;
 
-    new ContextMenu(html, ".item-block.owned", this.itemContextMenu);
-    // new ContextMenu(html, ".ability-block", this.abilityContextMenu);
-    new ContextMenu(html, ".context-items > span", this.itemListContextMenu);
-    new ContextMenu(html, ".item-list-add", this.itemListContextMenu, {
-      eventName: "click",
-    });
-    new ContextMenu(html, ".context-abilities", this.abilityListContextMenu);
-    new ContextMenu(html, ".ability-add-popup", this.abilityListContextMenu, {
-      eventName: "click",
-    });
-    new ContextMenu(html, ".trauma-item", this.traumaListContextMenu);
-    new ContextMenu(html, ".acquaintance", this.acquaintanceContextMenu);
+    const { implementation: ContextMenu } = foundry.applications.ux.ContextMenu;
+    const contextMenuOptions = { jQuery: false };
+    const root = html[0];
+
+    new ContextMenu(root, ".item-block.owned", this.itemContextMenu, contextMenuOptions);
+    new ContextMenu(root, ".context-items > span", this.itemListContextMenu, contextMenuOptions);
+    new ContextMenu(root, ".item-list-add", this.itemListContextMenu, { ...contextMenuOptions, eventName: "click" });
+    new ContextMenu(root, ".context-abilities", this.abilityListContextMenu, contextMenuOptions);
+    new ContextMenu(root, ".ability-add-popup", this.abilityListContextMenu, { ...contextMenuOptions, eventName: "click" });
+    new ContextMenu(root, ".trauma-item", this.traumaListContextMenu, contextMenuOptions);
+    new ContextMenu(root, ".acquaintance", this.acquaintanceContextMenu, contextMenuOptions);
 
     html.find('*[contenteditable="true"]').on("paste", (e) => {
       e.preventDefault();


### PR DESCRIPTION
Here's a patch that gets rid of the deprecation warnings on sheet load.

  - In Foundry VTT v13 the legacy global ContextMenu constructor still exists but emits deprecation warnings, plus it assumes jQuery-wrapped roots; the sheet was still invoking it with html (a jQuery wrapper) at multiple selectors (scripts/blades-alternate-actor-sheet.js:806).
  - The patch swaps to the v13-compliant API (foundry.applications.ux.ContextMenu.implementation) and tells it to run in non-jQuery mode, supplying the raw DOM root and explicit options for the click-only menus, which silences the console warnings.
  - After this change, context menus keep working (same selectors/callbacks), but the v13 console stops logging the deprecated-global/jQuery warnings when opening the alternate sheet.