### PR TITLE
feat: add multi-stage ability progress

### DIFF
--- a/scripts/handlebars-helpers.js
+++ b/scripts/handlebars-helpers.js
@@ -115,6 +115,17 @@ export const registerHandlebarsHelpers = function () {
     return actor.items.some((item) => item.name == ability_name);
   });
 
+  Handlebars.registerHelper("ability-cost", function (ability) {
+    const raw = ability?.system?.price ?? ability?.system?.cost ?? 1;
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed) || parsed < 1) return 1;
+    return Math.floor(parsed);
+  });
+
+  Handlebars.registerHelper("inc", function (value) {
+    return Number(value) + 1;
+  });
+
   Handlebars.registerHelper("times_from_2", function (n, block) {
     var accum = "";
     n = parseInt(n);
@@ -144,8 +155,13 @@ export const registerHandlebarsHelpers = function () {
   });
 
   Handlebars.registerHelper("times", function (n, block) {
-    var accum = "";
-    for (var i = 0; i < n; ++i) accum += block.fn(i);
+    let accum = "";
+    const count = Math.max(0, Number.parseInt(n, 10) || 0);
+    const data = block.data ? Handlebars.createFrame(block.data) : undefined;
+    for (let i = 0; i < count; ++i) {
+      if (data) data.index = i;
+      accum += block.fn(i, { data });
+    }
     return accum;
   });
 

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -53,8 +53,13 @@ export async function registerHooks() {
   //why isn't sheet showing up in update hook?
 
   Hooks.on("deleteItem", async (item, options, id) => {
-    if (item.type === "item" && item.parent) {
+    if (!item?.parent) return;
+    if (item.type === "item") {
       await Utils.toggleOwnership(false, item.parent, "item", item.id);
+    }
+    if (item.type === "ability" && item.parent.type === "character") {
+      const key = Utils.getAbilityProgressKeyFromData(item.name, item.id);
+      await Utils.updateAbilityProgressFlag(item.parent, key, 0);
     }
   });
 

--- a/styles/css/bitd-alt.css
+++ b/styles/css/bitd-alt.css
@@ -2132,13 +2132,15 @@
 .blades-alt.actor.sheet.pc .sheet-wrapper .tab-space .tab-content .tab .playbook .abilities .ability-list .ability-block:nth-child(even) {
   background-color: rgba(255, 255, 255, 0.3);
 }
-.blades-alt.actor.sheet.pc .sheet-wrapper .tab-space .tab-content .tab .playbook .abilities .ability-list .ability-block input {
-  margin: 0;
-  margin-right: 3px;
-  position: relative;
+.blades-alt.actor.sheet.pc .sheet-wrapper .tab-space .tab-content .tab .playbook .abilities .ability-list .ability-block .ability-checkboxes {
+  display: flex;
+  gap: 0.35em;
+  margin-right: 0.5em;
+  padding-top: 0.2em;
 }
-.blades-alt.actor.sheet.pc .sheet-wrapper .tab-space .tab-content .tab .playbook .abilities .ability-list .ability-block input.offset {
-  margin-top: -3px;
+.blades-alt.actor.sheet.pc .sheet-wrapper .tab-space .tab-content .tab .playbook .abilities .ability-list .ability-block .ability-checkboxes .ability-checkbox {
+  margin: 0;
+  position: relative;
 }
 .blades-alt.actor.sheet.pc .sheet-wrapper .tab-space .tab-content .tab .playbook .abilities .ability-list label {
   margin: 0;

--- a/styles/scss/import/character-sheet.scss
+++ b/styles/scss/import/character-sheet.scss
@@ -741,13 +741,15 @@
                   background-color: rgba(255, 255, 255, 0.3);
                 }
 
-                input {
-                  margin: 0;
-                  margin-right: 3px;
-                  position: relative;
+                .ability-checkboxes {
+                  display: flex;
+                  gap: 0.35em;
+                  margin-right: 0.5em;
+                  padding-top: 0.2em;
 
-                  &.offset {
-                    margin-top: -3px;
+                  .ability-checkbox {
+                    margin: 0;
+                    position: relative;
                   }
                 }
               }

--- a/templates/parts/ability.html
+++ b/templates/parts/ability.html
@@ -1,8 +1,18 @@
-<div class="ability-block" data-ability-id="{{ability._id}}">
-    <input type="checkbox" class="ability-checkbox main-checkbox" id="character-{{actor._id}}-ability-{{ability._id}}-1" {{checked (owns-ability actor ability.name)}}>
+<div class="ability-block" data-ability-id="{{ability._id}}" data-ability-owned-id="{{ability._ownedId}}" data-ability-name="{{ability.name}}" data-ability-cost="{{ability-cost ability}}" data-ability-progress="{{#if ability._progress}}{{ability._progress}}{{else}}0{{/if}}" data-ability-key="{{ability._progressKey}}">
+    <div class="ability-checkboxes">
+        {{#times (ability-cost ability)}}
+            <input
+                type="checkbox"
+                class="ability-checkbox"
+                id="character-{{../actor._id}}-ability-{{../ability._id}}-{{inc this}}"
+                data-ability-slot="{{inc this}}"
+                {{#ifCond (inc this) "<=" ../ability._progress}}checked{{/ifCond}}
+            >
+        {{/times}}
+    </div>
     <label for="character-{{actor._id}}-ability-{{ability._id}}-1">
         <span class="ability-name {{#if actor.flags.bitd-alternate-sheets.allow-edit}}{{#unless ability.system.virtual}}clickable-edit{{/unless}}{{/if}}">{{clean-name ability.name}}:</span>
         <span class="ability-description">{{{md ability.system.description}}}</span>
     </label>
-    {{#if allow_edit}}{{#if ability.flags.bitd-alternate-sheets.custom_ability}}<a class="ability-delete delete-button" data-type="ability" data-id="{{ability._id}}"><i class="fas fa-trash"></i></a>{{/if}}{{/if}}
+    {{#if allow_edit}}{{#if ability.flags.bitd-alternate-sheets.custom_ability}}<a class="ability-delete delete-button" data-type="ability" data-id="{{ability._ownedId}}" data-ability-name="{{ability.name}}"><i class="fas fa-trash"></i></a>{{/if}}{{/if}}
 </div>


### PR DESCRIPTION
### Summary

Some playbook abilities (e.g., veteran or Ghost Hunter abilities) require tracking more than a single checkbox. The alternate sheet previously exposed only a single toggle backed by the underlying ability Item, so players could not mark incremental progress toward multi-cost abilities on the sheet itself. This PR adds multi-stage support: if an ability defines a cost > 1, the sheet renders the correct number of pips, and clicking any pip updates the actor’s state accordingly.

### Implementation Details

  - Renders multi-cost abilities as a row of checkboxes sized to system.price/system.cost, using their value to display the current number of filled pips.
  - Tracks per-ability progress in flags.bitd-alternate-sheets.multiAbilityProgress, normalizing keys via Utils.getAbilityProgressKey*. When progress crosses the 0↔1 boundary we call Utils.toggleOwnership to sync the actual embedded ability Item so the core data model stays intact.
  - Ability delete logic (context menu, inline trash icon, checkbox drop to zero) always resolves to the owned Item id before deleting, preventing “Item … does not exist” errors when virtual entries refer to compendium documents.
  - On playbook swaps and deleteItem hooks, the stored progress flags are reset to avoid stale data when abilities disappear.
  - Template/CSS updates lay out the new checkbox rows, and handlebars helpers (ability-cost, inc, updated times) support rendering the pip count.