### PR TITLE
Compat/helper cleanup

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -3,6 +3,7 @@ import { BladesActiveEffect } from "../../../systems/blades-in-the-dark/module/b
 import { Utils, MODULE_ID } from "./utils.js";
 import { queueUpdate } from "./lib/update-queue.js";
 import { openCrewSelectionDialog } from "./lib/dialog-compat.js";
+import { enrichHTML } from "./compat.js";
 
 // import { migrateWorld } from "../../../systems/blades-in-the-dark/module/migration.js";
 
@@ -421,11 +422,11 @@ export class BladesAlternateActorSheet extends BladesSheet {
         if (entity?.type === "🕛 clock") {
         }
       }
-      let clockNotes = await TextEditor.enrichHTML(rawNotes, {
+      let clockNotes = await enrichHTML(rawNotes, {
         documents: false,
         async: true,
       });
-      sheetData.notes = await TextEditor.enrichHTML(clockNotes, {
+      sheetData.notes = await enrichHTML(clockNotes, {
         relativeTo: this.document,
         secrets: this.document.isOwner,
         async: true,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -163,7 +163,7 @@ export class Utils {
     let grouped_items = {};
     let generics = [];
     for (const item of item_list) {
-      let itemclass = getProperty(item, "system.class");
+      let itemclass = foundry.utils.getProperty(item, "system.class");
       if (itemclass === "") {
         generics.push(item);
       } else {


### PR DESCRIPTION
### Summary

Foundry v13+ logs deprecation warnings for global helpers like getProperty and TextEditor.enrichHTML. Using the compat wrappers avoids noise now and future breakage when the globals are removed. And still works on v12.

- Route HTML enrichment through the compat helper so sheet notes use the namespaced API when available and the legacy global otherwise.
- Swap the remaining getProperty call in item grouping to foundry.utils.getProperty via the compat path, eliminating the v13 deprecation warning.
