### PR TITLE
Fix/manifest schema resolves Issue #99

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "library": "false",
   "compatibility": {
     "minimum": 12,
-    "verified": 12
+    "verified": 13
   },
   "authors": [
     {


### PR DESCRIPTION
  Summary

  - Move system dependency to the v12+ manifest schema (relationships.systems with id: "blades-in-the-dark"), clearing the setup-page warnings.
  - Remove deprecated/unknown keys (manifestPlusVersion, minimumCoreVersion, old dependencies/conflicts) to match the current Foundry manifest format.
  - Update compatibility metadata to mark the module verified on core v13.