### PR TITLE
 Use theme clock SVGs in enricher to support all slice counts

### DIFF
--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -29,6 +29,9 @@ export async function registerHooks() {
         enricher: async (match, options) => {
           let linkedDoc = await fromUuid(match[2]);
           if (linkedDoc?.type == "🕛 clock") {
+            const type = linkedDoc.system?.type ?? "";
+            const value = linkedDoc.system?.value ?? 0;
+            const color = linkedDoc.system?.color ?? "black";
             const doc = document.createElement("div");
             doc.classList.add("linkedClock");
             let droppedItemTextRaw = match[0];
@@ -37,7 +40,10 @@ export async function registerHooks() {
               droppedItemRegex,
               `{${linkedDoc.name}}`
             );
-            doc.innerHTML = `<img src="systems/blades-in-the-dark/styles/assets/progressclocks-svg/Progress Clock ${linkedDoc.system.type}-${linkedDoc.system.value}.svg" class="clockImage" data-uuid="${match[2]}" />
+            const clockImgSrc = type && value !== undefined
+              ? `systems/blades-in-the-dark/themes/${color}/${type}clock_${value}.svg`
+              : linkedDoc.img;
+            doc.innerHTML = `<img src="${clockImgSrc}" class="clockImage" data-uuid="${match[2]}" />
                 <br/> 
                 ${droppedItemTextRenamed}`;
             // ${match[0]}`;


### PR DESCRIPTION
The previous path only included 4/6/8 clocks, so 10/12 clocks rendered blank in notes. The theme assets include complete SVG sets for all sizes.

  - Update the TextEditor enricher to pull clock images from the system’s theme assets (systems/blades-in-the-dark/themes/{color}/{size}clock_{value}.svg) instead of the limited progressclocks-svg set.
  - Supports 10/12-segment clocks (and color variants) in enriched text/notes, matching what the clock sheet uses.
