### PR TITLE
Fix/deepcut load encumbered

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -698,6 +698,9 @@ export class BladesAlternateActorSheet extends BladesSheet {
         case "BITD.Conspicuous":
           sheetData.max_load = sheetData.system.base_max_load + 6;
           break;
+        case "BITD.Encumbered":
+          sheetData.max_load = sheetData.system.base_max_load + 9;
+          break;
         default:
           sheetData.system.selected_load_level = "BITD.Discreet";
           sheetData.max_load = sheetData.system.base_max_load + 4;


### PR DESCRIPTION
  - Added the missing Encumbered option to the Deep Cut load selector so users can choose all Deep Cut encumbrance states (Discreet/Conspicuous/Encumbered).
  - Updated the Deep Cut max-load calculation to handle Encumbered (uses base_max_load + 9) instead of falling back to Discreet.
  - Result: Deep Cut load selection now persists correctly for all tiers, and the thresholds reflect the Deep Cut progression.