### PR TITLE
refactor: add safeUpdate helper for document updates

### DIFF
--- a/scripts/clocks.js
+++ b/scripts/clocks.js
@@ -1,4 +1,4 @@
-import { queueUpdate } from "./lib/update-queue.js";
+import { safeUpdate } from "./lib/update-queue.js";
 
 /**
  * Find content-link elements pointing to clock actors and replace them with clock displays.
@@ -144,9 +144,7 @@ export function setupGlobalClockHandlers() {
       updateData["prototypeToken.texture.src"] = imgPath;
     }
 
-    await queueUpdate(async () => {
-      await doc.update(updateData, { render: false });
-    });
+    await safeUpdate(doc, updateData, { render: false });
   });
 
   $body.on("contextmenu", ".blades-clock", async (e) => {
@@ -180,9 +178,7 @@ export function setupGlobalClockHandlers() {
       updateData["prototypeToken.texture.src"] = imgPath;
     }
 
-    await queueUpdate(async () => {
-      await doc.update(updateData, { render: false });
-    });
+    await safeUpdate(doc, updateData, { render: false });
   });
 
   $body.on("change click", ".blades-clock input[type='radio']", (e) => {

--- a/scripts/sheets/actor/smart-edit.js
+++ b/scripts/sheets/actor/smart-edit.js
@@ -1,4 +1,5 @@
 import { openCardSelectionDialog } from "../../lib/dialog-compat.js";
+import { safeUpdate } from "../../lib/update-queue.js";
 import { Utils } from "../../utils.js";
 
 export async function handleSmartEdit(sheet, event) {
@@ -319,7 +320,8 @@ function _normalizeEmbeddedItemSystem(system, ctx) {
 
 async function updateSmartField(sheet, field, value, header) {
   try {
-    await sheet.actor.update({ [field]: value });
+    const didUpdate = await safeUpdate(sheet.actor, { [field]: value });
+    if (!didUpdate) return;
   } catch (err) {
     // Preserve original error as cause when wrapping non-Errors
     const error = err instanceof Error ? err : new Error(String(err), { cause: err });


### PR DESCRIPTION
## Summary
- add safeUpdate helper with ownership/no-op/queueUpdate guards
- use safeUpdate for clock updates
- use safeUpdate for smart field updates

## Test plan
- smart fields: update value, no-op selection
- clocks: click + right-click in notes and harm clock
- rapid clicks to confirm serialization
