### PR TITLE
Add compendium caching for faster sheet renders

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -416,6 +416,7 @@ export class BladesAlternateActorSheet extends BladesSheet {
 
   /** @override */
   async getData() {
+    const getDataStart = performance.now();
     let sheetData = await super.getData();
     Utils.ensureAllowEdit(this);
     const persistedUi = await Utils.loadUiState(this);
@@ -792,6 +793,10 @@ export class BladesAlternateActorSheet extends BladesSheet {
       : acquaintanceList;
     sheetData.display_acquaintances = filteredAcqs;
 
+    Profiler.log("ActorSheet.getData", {
+      duration: performance.now() - getDataStart,
+      actor: this.actor?.name,
+    });
     return sheetData;
   }
 
@@ -1062,7 +1067,7 @@ export class BladesAlternateActorSheet extends BladesSheet {
       targetInput.prop("checked", true);
     }
 
-    // Direct Foundry update - let Foundry's hook handle the render
+    // Direct Foundry update - let Foundry handle the render for multi-client sync
     try {
       await queueUpdate(async () => {
         await this.actor.update({ [fieldName]: newValue });
@@ -1410,12 +1415,12 @@ export class BladesAlternateActorSheet extends BladesSheet {
               name: itemName,
               progress: targetProgress
             }
-          }, { render: false }));
+          }));
           itemBlock.classList.add("owned");
         } else {
           await queueUpdate(() => this.actor.update({
             [`flags.bitd-alternate-sheets.equipped-items.-=${itemId}`]: null
-          }, { render: false }));
+          }));
           itemBlock.classList.remove("owned");
         }
 

--- a/scripts/blades-alternate-crew-sheet.js
+++ b/scripts/blades-alternate-crew-sheet.js
@@ -25,6 +25,7 @@ export class BladesAlternateCrewSheet extends SystemCrewSheet {
 
   /** @override */
   async getData(options) {
+    const getDataStart = performance.now();
     const sheetData = await super.getData(options);
     Utils.ensureAllowEdit(this);
     const persistedUi = await Utils.loadUiState(this);
@@ -74,6 +75,10 @@ export class BladesAlternateCrewSheet extends SystemCrewSheet {
     sheetData.display_acquaintances = filteredAcqs;
     sheetData.showFilteredAcquaintances = this.showFilteredAcquaintances;
 
+    Profiler.log("CrewSheet.getData", {
+      duration: performance.now() - getDataStart,
+      actor: this.actor?.name,
+    });
     return sheetData;
   }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,3 +1,5 @@
+import { Utils } from "./utils.js";
+
 export const registerSystemSettings = function () {
   game.settings.register("bitd-alternate-sheets", "populateFromCompendia", {
     name: "Load Compendium Objects",
@@ -7,7 +9,8 @@ export const registerSystemSettings = function () {
     type: Boolean, // Number, Boolean, String,
     default: true,
     onChange: (value) => {
-      // value is the new value of the setting
+      // Clear cache when compendium source setting changes
+      Utils._invalidateCache(null);
     },
   });
 
@@ -18,6 +21,10 @@ export const registerSystemSettings = function () {
     config: true,
     type: Boolean,
     default: true,
+    onChange: (value) => {
+      // Clear cache when world source setting changes
+      Utils._invalidateCache(null);
+    },
   });
 
   game.settings.register("bitd-alternate-sheets", "searchAllPacks", {
@@ -27,6 +34,10 @@ export const registerSystemSettings = function () {
     config: true,
     type: Boolean,
     default: false,
+    onChange: (value) => {
+      // Clear cache when search scope setting changes
+      Utils._invalidateCache(null);
+    },
   });
 
   game.settings.register(


### PR DESCRIPTION
## Summary

- Implement module-wide compendium caching to dramatically improve sheet render performance
- Pre-cache common item types on startup for instant initial renders
- Add surgical cache invalidation to keep data fresh

## Performance Results

| Metric | Before | After |
|--------|--------|-------|
| Actor sheet getData | ~550-650ms | ~2-3ms |
| Crew sheet getData | ~170-220ms | ~0.8-2.4ms |
| Startup pre-cache | N/A | ~1s (one-time) |

## Changes

**Cache Infrastructure (utils.js):**
- Module-level `_compendiumCache` Map
- Settings-aware cache keys for automatic invalidation on config changes
- `_preCacheCommonTypes()` pre-caches 9 item types on startup
- Surgical `_invalidateCache(itemType)` clears only affected entries

**Cache Invalidation (hooks.js):**
- Hooks for `updateCompendium`, `createItem`, `updateItem`, `deleteItem`
- Hooks for `createActor`, `updateActor`, `deleteActor` (NPCs)
- Pre-cache call on `ready` hook

**Settings Integration (settings.js):**
- `onChange` callbacks invalidate cache when source settings change

**Multi-Client Sync Fix:**
- Remove `{ render: false }` from teeth and item checkbox updates
- Ensures updates sync properly across all connected clients
- Caching makes re-renders fast enough to avoid visual flashes

**Cleanup:**
- Remove empty `updateActor` and `createActor` hooks that added overhead
- Remove unused `BladesAlternateActorSheet` import from hooks.js