### PR TITLE
Remove collapsible section and filter UI controls

### DIFF
--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -140,7 +140,7 @@
       <section class="tab-content">
         <div class="tab" data-tab="playbook" data-group="primary-tabs">
           <div class="playbook">
-            <section class="abilities section-block {{#if (lookup collapsedSections 'abilities')}}collapsed{{/if}}" data-section-key="abilities">
+            <section class="abilities section-block" data-section-key="abilities">
               {{> "modules/bitd-alternate-sheets/templates/parts/section-controls.html"
                 label=(localize "BITD.SpecialAbilities")
                 flex=false
@@ -175,7 +175,7 @@
                 </section>
               </div>
             </section>
-            <section class="playbook-items item-list section-block {{#if (lookup collapsedSections 'items')}}collapsed{{/if}}" data-section-key="items">
+            <section class="playbook-items item-list section-block" data-section-key="items">
               {{> "modules/bitd-alternate-sheets/templates/parts/section-controls.html"
                 label=(localize "bitd-alt.items")
                 flex=true
@@ -196,7 +196,7 @@
               {{/each}}
               </div>
             </section>
-            <section class="friends-rivals section-block {{#if (lookup collapsedSections 'acquaintances')}}collapsed{{/if}}" data-section-key="acquaintances">
+            <section class="friends-rivals section-block" data-section-key="acquaintances">
               {{> "modules/bitd-alternate-sheets/templates/parts/section-controls.html"
                 label=(localize acquaintances_label)
                 flex=false
@@ -225,7 +225,7 @@
               {{/with}}
               {{/each}}
             </section>
-            <section class="xp-notes section-block {{#if (lookup collapsedSections 'xp')}}collapsed{{/if}}" data-section-key="xp">
+            <section class="xp-notes section-block" data-section-key="xp">
               {{> "modules/bitd-alternate-sheets/templates/parts/section-controls.html"
                 label="XP"
                 sectionKey="xp"

--- a/templates/crew-sheet.html
+++ b/templates/crew-sheet.html
@@ -290,7 +290,7 @@
         </section>
       </div>
 
-      <div id="crew-{{_id}}-contacts" class="tab flex-vertical section-block {{#if (lookup collapsedSections 'acquaintances')}}collapsed{{/if}}" data-tab="contacts" data-section-key="acquaintances">
+      <div id="crew-{{_id}}-contacts" class="tab flex-vertical section-block" data-tab="contacts" data-section-key="acquaintances">
         <div class="flex-horizontal contacts-actions">
           <p>
             <a class="import-contacts" data-tooltip="{{localize 'BITD.ImportPlaybookContacts'}}"><i

--- a/templates/parts/section-controls.html
+++ b/templates/parts/section-controls.html
@@ -1,13 +1,5 @@
 <header class="full-bar {{#if flex}}flex-header context-items{{/if}}">
-  <a class="collapse-toggle" data-action="toggle-section-collapse" data-section-key="{{sectionKey}}">
-    <i class="fas {{#if isCollapsed}}fa-caret-right{{else}}fa-caret-down{{/if}}"></i>
-  </a>
   <span>{{label}}</span>
-  {{#if showFilter}}
-  <a class="filter-toggle {{#if isFiltered}}active{{/if}}" data-action="toggle-filter" data-filter-target="{{filterTarget}}" data-tooltip="Show checked only">
-    <i class="fas fa-filter"></i>
-  </a>
-  {{/if}}
   {{#if showAdd}}
   <a class="{{addClass}}" {{#if addDataAttrs}}{{{addDataAttrs}}}{{/if}}>
     <i class="fas fa-plus"></i>


### PR DESCRIPTION
## Summary
- Removes collapse toggle (caret) and filter toggle (funnel) from section headers
- Sections now always display expanded and unfiltered
- Underlying implementation code preserved for potential future use