### PR TITLE
Add Clear Load button to load popout with GM setting

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -14,6 +14,7 @@
     "bitd-alt.Edit": "Bearbeiten",
     "bitd-alt.Select": "Auswählen",
     "bitd-alt.Clear": "Leeren",
+    "bitd-alt.ClearLoad": "Ausrüstung leeren",
     "bitd-alt.CustomValue": "Eigener Wert:",
     "bitd-alt.SelectToAddAbility": "Hinzuzufügende Fähigkeiten wählen",
     "bitd-alt.SelectToAddItem": "Hinzuzufügende Gegenstände wählen",

--- a/languages/en.json
+++ b/languages/en.json
@@ -14,6 +14,7 @@
     "bitd-alt.Edit": "Edit",
     "bitd-alt.Select": "Select",
     "bitd-alt.Clear": "Clear",
+    "bitd-alt.ClearLoad": "Clear Load",
     "bitd-alt.CustomValue": "Custom:",
     "bitd-alt.SelectToAddAbility": "Select Abilities to Add",
     "bitd-alt.SelectToAddItem": "Select Items to Add",

--- a/languages/it.json
+++ b/languages/it.json
@@ -14,6 +14,7 @@
     "bitd-alt.Edit": "Modifica",
     "bitd-alt.Select": "Seleziona",
     "bitd-alt.Clear": "Pulisci",
+    "bitd-alt.ClearLoad": "Svuota carico",
     "bitd-alt.CustomValue": "Personalizzato:",
     "bitd-alt.SelectToAddAbility": "Seleziona un abilità da aggiungere",
     "bitd-alt.SelectToAddItem": "Seleziona un oggetto da aggiungere",

--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -450,6 +450,7 @@ export class BladesAlternateActorSheet extends BladesSheet {
     sheetData.load_open = this.load_open;
     sheetData.allow_edit = this.allow_edit;
     sheetData.show_debug = this.show_debug;
+    sheetData.showClearLoadButton = game.user.isGM || game.settings.get("bitd-alternate-sheets", "showClearLoadButton");
 
     const systemCrewEntries = this._getSystemCrewEntries();
     const primaryCrew = this._getPrimaryCrewEntry(systemCrewEntries);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -65,4 +65,13 @@ export const registerSystemSettings = function () {
     type: Boolean,
     default: false,
   });
+
+  game.settings.register("bitd-alternate-sheets", "showClearLoadButton", {
+    name: "Show Clear Load Button to Players",
+    hint: "Show the Clear Load button to players in the load popout. GMs always see it.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
 };

--- a/templates/parts/load.html
+++ b/templates/parts/load.html
@@ -4,6 +4,9 @@
     {{selectOptions load_levels selected=system.selected_load_level
     localize=true}}
   </select>
+  {{#if showClearLoadButton}}
+  <button type="button" class="clearLoad">{{localize "bitd-alt.ClearLoad"}}</button>
+  {{/if}}
 </div>
 <!--<div class="load-description">-->
 <!--STUFF-->


### PR DESCRIPTION
## Summary
- Adds a "Clear Load" button to the load popout dialog
- New world setting `showClearLoadButton` controls player visibility (default: false)
- GMs always see the button; players only see it when the setting is enabled
- Includes localization for English, German, and Italian