### PR TITLE
Add release validation safeguard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,33 @@ jobs:
           manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
           download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
+      # Validate that substitutions were applied
+      - name: Validate manifest substitutions
+        run: |
+          echo "Validating module.json substitutions..."
+
+          # Check for leftover placeholder text
+          if grep -q "This is auto replaced" module.json; then
+            echo "::error::Variable substitution failed - placeholder text still present in module.json"
+            echo "Ensure url, manifest, and download fields exist in module.json"
+            exit 1
+          fi
+
+          # Check version is not the placeholder
+          VERSION=$(jq -r '.version' module.json)
+          if [ "$VERSION" = "0.0.1" ]; then
+            echo "::error::Version was not substituted - still shows 0.0.1"
+            exit 1
+          fi
+
+          # Check download URL is valid
+          if ! jq -e '.download | startswith("https://")' module.json > /dev/null; then
+            echo "::error::Download URL is missing or invalid"
+            exit 1
+          fi
+
+          echo "Manifest validation passed - version: $VERSION"
+
       # Create a zip file with all files required by the module to add to the release
       - run: zip -r ./module.zip module.json LICENSE styles/ scripts/ templates/ languages/ images/
 


### PR DESCRIPTION
## Summary
- Adds validation step to GitHub Actions release workflow
- Catches failed variable substitutions before broken release is published

## Background
The 1.0.18 release was broken because placeholder fields (`url`, `manifest`, `download`) were accidentally removed from `module.json`. The `microsoft/variable-substitution@v1` action silently did nothing since there were no keys to substitute into.

## Changes
Adds a "Validate manifest substitutions" step that checks:
1. No leftover `"This is auto replaced"` placeholder text in module.json
2. Version is not the development placeholder (`0.0.1`)
3. Download URL starts with `https://`

If any check fails, the workflow errors with a descriptive message before creating the release.

## Test plan
- [x] Tested on fork with `v0.0.0-test` release - workflow passed, validation output: `Manifest validation passed - version: 0.0.0-test`
- [x] Test release artifacts cleaned up

## Rollback
If needed, simply remove the "Validate manifest substitutions" step from the workflow.