### PR TITLE
Fix zero-load items incrementing load counter (#157)

### DIFF
--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -730,12 +730,10 @@ export class BladesAlternateActorSheet extends BladesSheet {
     if (equipped) {
       for (const i of Object.values(equipped)) {
         if (!i) continue; // Skip null/undefined entries
-        // Use progress if defined, otherwise fall back to load (backwards compat)
-        if (i.progress !== undefined) {
-          loadout += parseInt(i.progress) || 0;
-        } else {
-          loadout += parseInt(i.load) || 0;
-        }
+        // Use load field (actual item load) for the sum.
+        // The progress field tracks visual checkbox state and may be
+        // clamped to 1 for zero-load items.
+        loadout += parseInt(i.load) || 0;
       }
     }
 

--- a/templates/parts/item.html
+++ b/templates/parts/item.html
@@ -1,4 +1,4 @@
-<div class="item-block {{#if item.owned}}owned{{/if}}" data-item-id="{{item._id}}" data-item-name="{{item.name}}" data-item-load="{{default item.system.load 1}}" data-item-progress="{{item._progress}}">
+<div class="item-block {{#if item.owned}}owned{{/if}}" data-item-id="{{item._id}}" data-item-name="{{item.name}}" data-item-load="{{item.system.load}}" data-item-progress="{{item._progress}}">
   <div class="checkbox"><!--
   -->{{#times (max item.system.load 1)}}<!--
     -->{{#if @index}}<span class="join-line"></span>{{/if}}<!--


### PR DESCRIPTION
## Summary

  Fixes #157 — zero-load items (e.g., Spiritbane Charm) incorrectly added 1 to the load total when equipped.

  ## Root Cause

  Two compounding issues:

  1. **Template** (`templates/parts/item.html`): `{{default item.system.load 1}}` treats `0` as falsy in Handlebars, so
   `data-item-load` was emitted as `"1"` for zero-load items instead of `"0"`.

  2. **Load sum** (`scripts/blades-alternate-actor-sheet.js`): The loadout calculation used `i.progress` (the visual
  checkbox state, clamped to min 1 so the checkbox renders as checked) instead of `i.load` (the actual item load
  value).

  ## Fix

  - Use `{{item.system.load}}` in the template so zero-load items correctly report `0`. Undefined load values fall
  through to the existing JS fallback.
  - Sum on `i.load` (actual load value) instead of `i.progress` (visual state). The `load` field is present in both old
   and new flag formats.

  ## Testing

  - Manual testing: equipping Spiritbane Charm no longer increments load
  - Quench test suite passes (all existing tests + new zero-load regression tests in the test harness module)
  - Tested with FVTT v13.351
  - I also ran the Quench tests on FVTT v14.358 and everything passed (Version 14 Testing 3)